### PR TITLE
update GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
         run: git push origin ${{ matrix.school }}
         if: github.ref_name == 'main'
       - name: Store rendered HTML for link checking
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.school }}
           path: _build/html
@@ -71,7 +71,7 @@ jobs:
         run: gem install html-proofer
 
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.school }}
           path: _build/html


### PR DESCRIPTION
Replaces #126 and #127, since [they need to be upgraded concurrently](https://github.com/actions/download-artifact?tab=readme-ov-file#breaking-changes).