### PR TITLE
specify the canonical URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ exclude_patterns:
 execute:
   execute_notebooks: "off"
 html:
+  # useful since the site's being deployed for each school
+  baseurl: https://python-public-policy.afeld.me/en/columbia/
   use_repository_button: true
   extra_navbar: ""
   home_page_in_navbar: false

--- a/extras/lib/school.py
+++ b/extras/lib/school.py
@@ -156,6 +156,7 @@ EXEMPT = [
     "- [google colab](https://colab.research.google.com/)",
     "anaconda",
     "autograder",  # matches "grader"
+    "baseurl: ",  # _config.yml
     "built around it",  # referring to Colab
     "columbia's graduate school of architecture",  # bio
     "conda activate",


### PR DESCRIPTION
Should help with SEO, since the school sites have so much overlap.